### PR TITLE
마이페이지 기능 구현

### DIFF
--- a/src/main/java/com/unide/backend/domain/auth/service/AuthService.java
+++ b/src/main/java/com/unide/backend/domain/auth/service/AuthService.java
@@ -160,6 +160,7 @@ public class AuthService {
         MyPage myPage = MyPage.builder()
                 .user(savedUser)
                 .nickname(savedUser.getNickname())
+                .isPublic(true)
                 .build();
         myPageRepository.save(myPage);
 

--- a/src/main/java/com/unide/backend/domain/auth/service/AuthService.java
+++ b/src/main/java/com/unide/backend/domain/auth/service/AuthService.java
@@ -7,15 +7,6 @@ import java.time.LocalDateTime;
 import java.util.Random;
 import java.util.UUID;
 
-import jakarta.mail.MessagingException;
-import jakarta.mail.internet.MimeMessage;
-
-import lombok.RequiredArgsConstructor;
-import com.unide.backend.domain.auth.dto.LogoutRequestDto;
-import com.unide.backend.domain.auth.dto.PasswordResetCodeVerifyRequestDto;
-import com.unide.backend.domain.auth.dto.PasswordResetCodeVerifyResponseDto;
-import com.unide.backend.domain.auth.dto.TokenRefreshRequestDto;
-
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -26,22 +17,44 @@ import org.thymeleaf.context.Context;
 import org.thymeleaf.spring6.SpringTemplateEngine;
 
 import com.unide.backend.domain.admin.repository.BlacklistRepository;
-import com.unide.backend.domain.auth.dto.*;
-import com.unide.backend.domain.auth.entity.*;
-import com.unide.backend.domain.auth.repository.*;
+import com.unide.backend.domain.auth.dto.AvailabilityResponseDto;
+import com.unide.backend.domain.auth.dto.BlacklistCheckRequestDto;
+import com.unide.backend.domain.auth.dto.BlacklistCheckResponseDto;
+import com.unide.backend.domain.auth.dto.EmailRequestDto;
+import com.unide.backend.domain.auth.dto.LoginRequestDto;
+import com.unide.backend.domain.auth.dto.LoginResponseDto;
+import com.unide.backend.domain.auth.dto.LogoutRequestDto;
+import com.unide.backend.domain.auth.dto.PasswordResetCodeVerifyRequestDto;
+import com.unide.backend.domain.auth.dto.PasswordResetCodeVerifyResponseDto;
+import com.unide.backend.domain.auth.dto.PasswordResetRequestDto;
+import com.unide.backend.domain.auth.dto.RegisterRequestDto;
+import com.unide.backend.domain.auth.dto.TokenRefreshRequestDto;
+import com.unide.backend.domain.auth.dto.WelcomeEmailRequestDto;
+import com.unide.backend.domain.auth.entity.EmailVerificationCode;
+import com.unide.backend.domain.auth.entity.PasswordResetToken;
+import com.unide.backend.domain.auth.entity.RefreshToken;
+import com.unide.backend.domain.auth.repository.EmailVerificationCodeRepository;
+import com.unide.backend.domain.auth.repository.PasswordResetTokenRepository;
+import com.unide.backend.domain.auth.repository.RefreshTokenRepository;
+import com.unide.backend.domain.instructor.entity.InstructorApplication;
+import com.unide.backend.domain.instructor.entity.UserPortfolioFile;
+import com.unide.backend.domain.instructor.repository.InstructorApplicationRepository;
+import com.unide.backend.domain.instructor.repository.UserPortfolioFileRepository;
+import com.unide.backend.domain.mypage.entity.MyPage;
+import com.unide.backend.domain.mypage.repository.MyPageRepository;
 import com.unide.backend.domain.terms.entity.UserTermsConsent;
 import com.unide.backend.domain.terms.repository.UserTermsConsentRepository;
 import com.unide.backend.domain.user.entity.User;
+import com.unide.backend.domain.user.entity.UserRole;
 import com.unide.backend.domain.user.entity.UserStatus;
 import com.unide.backend.domain.user.repository.UserRepository;
 import com.unide.backend.domain.user.service.UserLoginService;
 import com.unide.backend.global.exception.AuthException;
 import com.unide.backend.global.security.jwt.JwtTokenProvider;
-import com.unide.backend.domain.instructor.entity.InstructorApplication;
-import com.unide.backend.domain.instructor.entity.UserPortfolioFile;
-import com.unide.backend.domain.instructor.repository.InstructorApplicationRepository;
-import com.unide.backend.domain.instructor.repository.UserPortfolioFileRepository;
-import com.unide.backend.domain.user.entity.UserRole;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
@@ -62,6 +75,7 @@ public class AuthService {
     private final PasswordResetTokenRepository passwordResetTokenRepository;
     private final UserPortfolioFileRepository userPortfolioFileRepository;
     private final InstructorApplicationRepository instructorApplicationRepository;
+    private final MyPageRepository myPageRepository;
 
     /**
      * 이메일 사용 가능 여부를 확인하는 메서드
@@ -141,6 +155,13 @@ public class AuthService {
         }
 
         User savedUser = userRepository.save(newUser);
+
+        // MyPage 자동 생성 (nickname은 User의 nickname을 사용)
+        MyPage myPage = MyPage.builder()
+                .user(savedUser)
+                .nickname(savedUser.getNickname())
+                .build();
+        myPageRepository.save(myPage);
 
         // 요청 DTO의 role이 INSTRUCTOR일 때 지원서 저장
         if (requestDto.getRole() == UserRole.INSTRUCTOR) {

--- a/src/main/java/com/unide/backend/domain/bookmark/entity/Bookmark.java
+++ b/src/main/java/com/unide/backend/domain/bookmark/entity/Bookmark.java
@@ -1,0 +1,46 @@
+package com.unide.backend.domain.bookmark.entity;
+
+import com.unide.backend.common.entity.BaseTimeEntity;
+import com.unide.backend.domain.problem.entity.Problem;
+import com.unide.backend.domain.user.entity.User;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "bookmarks", uniqueConstraints = {
+    @UniqueConstraint(columnNames = {"user_id", "problem_id"})
+})
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Bookmark extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "problem_id", nullable = false)
+    private Problem problem;
+
+    @Builder
+    public Bookmark(User user, Problem problem) {
+        this.user = user;
+        this.problem = problem;
+    }
+}

--- a/src/main/java/com/unide/backend/domain/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/com/unide/backend/domain/bookmark/repository/BookmarkRepository.java
@@ -1,0 +1,15 @@
+package com.unide.backend.domain.bookmark.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.unide.backend.domain.bookmark.entity.Bookmark;
+
+public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
+
+    @Query("SELECT b.problem.id FROM Bookmark b WHERE b.user.id = :userId")
+    List<Long> findBookmarkedProblemIdsByUserId(@Param("userId") Long userId);
+}

--- a/src/main/java/com/unide/backend/domain/mypage/controller/MyPageController.java
+++ b/src/main/java/com/unide/backend/domain/mypage/controller/MyPageController.java
@@ -1,14 +1,23 @@
 package com.unide.backend.domain.mypage.controller;
 
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
 import com.unide.backend.common.response.MessageResponseDto;
 import com.unide.backend.domain.mypage.dto.MyPageResponseDto;
 import com.unide.backend.domain.mypage.dto.MyPageUpdateRequestDto;
 import com.unide.backend.domain.mypage.service.MyPageService;
 import com.unide.backend.global.security.auth.PrincipalDetails;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -33,12 +42,12 @@ public class MyPageController {
     }
 
     @PutMapping
-    public ResponseEntity<MyPageResponseDto> updateMyPage(
+    public ResponseEntity<MessageResponseDto> updateMyPage(
             @AuthenticationPrincipal PrincipalDetails principalDetails,
             @RequestBody MyPageUpdateRequestDto requestDto) {
         Long userId = principalDetails.getUser().getId();
-        MyPageResponseDto response = myPageService.updateMyPage(userId, requestDto);
-        return ResponseEntity.ok(response);
+        myPageService.updateMyPage(userId, requestDto);
+        return ResponseEntity.ok(new MessageResponseDto("마이페이지가 성공적으로 수정되었습니다."));
     }
 
     @DeleteMapping
@@ -46,5 +55,12 @@ public class MyPageController {
         Long userId = principalDetails.getUser().getId();
         myPageService.deleteMyPage(userId);
         return ResponseEntity.ok(new MessageResponseDto("마이페이지가 삭제되었습니다."));
+    }
+
+    @PostMapping("/initialize")
+    public ResponseEntity<MessageResponseDto> initializeMyPage(@AuthenticationPrincipal PrincipalDetails principalDetails) {
+        Long userId = principalDetails.getUser().getId();
+        myPageService.initializeMyPage(userId);
+        return ResponseEntity.ok(new MessageResponseDto("마이페이지가 시작되었습니다."));
     }
 }

--- a/src/main/java/com/unide/backend/domain/mypage/controller/MyPageController.java
+++ b/src/main/java/com/unide/backend/domain/mypage/controller/MyPageController.java
@@ -1,0 +1,50 @@
+package com.unide.backend.domain.mypage.controller;
+
+import com.unide.backend.common.response.MessageResponseDto;
+import com.unide.backend.domain.mypage.dto.MyPageResponseDto;
+import com.unide.backend.domain.mypage.dto.MyPageUpdateRequestDto;
+import com.unide.backend.domain.mypage.service.MyPageService;
+import com.unide.backend.global.security.auth.PrincipalDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/mypage")
+public class MyPageController {
+    private final MyPageService myPageService;
+
+    @GetMapping("/{nickname}")
+    public ResponseEntity<MyPageResponseDto> getMyPageByNickname(
+            @PathVariable String nickname,
+            @AuthenticationPrincipal PrincipalDetails principalDetails) {
+        Long requestUserId = principalDetails != null ? principalDetails.getUser().getId() : null;
+        MyPageResponseDto response = myPageService.getMyPageByNickname(nickname, requestUserId);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping
+    public ResponseEntity<MyPageResponseDto> getMyPage(@AuthenticationPrincipal PrincipalDetails principalDetails) {
+        Long userId = principalDetails.getUser().getId();
+        MyPageResponseDto response = myPageService.getMyPage(userId);
+        return ResponseEntity.ok(response);
+    }
+
+    @PutMapping
+    public ResponseEntity<MyPageResponseDto> updateMyPage(
+            @AuthenticationPrincipal PrincipalDetails principalDetails,
+            @RequestBody MyPageUpdateRequestDto requestDto) {
+        Long userId = principalDetails.getUser().getId();
+        MyPageResponseDto response = myPageService.updateMyPage(userId, requestDto);
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping
+    public ResponseEntity<MessageResponseDto> deleteMyPage(@AuthenticationPrincipal PrincipalDetails principalDetails) {
+        Long userId = principalDetails.getUser().getId();
+        myPageService.deleteMyPage(userId);
+        return ResponseEntity.ok(new MessageResponseDto("마이페이지가 삭제되었습니다."));
+    }
+}

--- a/src/main/java/com/unide/backend/domain/mypage/dto/MyPageResponseDto.java
+++ b/src/main/java/com/unide/backend/domain/mypage/dto/MyPageResponseDto.java
@@ -14,6 +14,9 @@ import lombok.Getter;
 @AllArgsConstructor
 @Builder
 public class MyPageResponseDto {
+    // 마이페이지 ID
+    private final Long id;
+    
     // 사용자 기본 정보
     private final Long userId;
     private final String nickname;
@@ -22,6 +25,7 @@ public class MyPageResponseDto {
     private final List<String> preferredLanguage;
     private final String role;
     private final LocalDateTime joinedAt;
+    private final LocalDateTime updatedAt;
     private final Boolean isPublic;
     
     // 문제 풀이 관련

--- a/src/main/java/com/unide/backend/domain/mypage/dto/MyPageResponseDto.java
+++ b/src/main/java/com/unide/backend/domain/mypage/dto/MyPageResponseDto.java
@@ -1,0 +1,36 @@
+// 마이페이지 통합 조회 응답 DTO
+// User 정보 + MyPage 정보 + 통계 + 제출 내역을 한 번에 반환
+
+package com.unide.backend.domain.mypage.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class MyPageResponseDto {
+    // 사용자 기본 정보
+    private final Long userId;
+    private final String nickname;
+    private final String avatarUrl;
+    private final String bio;
+    private final List<String> preferredLanguage;
+    private final String role;
+    private final LocalDateTime joinedAt;
+    private final Boolean isPublic;
+    
+    // 문제 풀이 관련
+    private final List<Long> solvedProblems;
+    private final List<Long> bookmarkedProblems;
+    
+    // 최근 제출 내역
+    private final List<SubmissionItem> recentSubmissions;
+    
+    // 통계
+    private final UserStats stats;
+}

--- a/src/main/java/com/unide/backend/domain/mypage/dto/MyPageUpdateRequestDto.java
+++ b/src/main/java/com/unide/backend/domain/mypage/dto/MyPageUpdateRequestDto.java
@@ -1,0 +1,14 @@
+package com.unide.backend.domain.mypage.dto;
+
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MyPageUpdateRequestDto {
+    private String nickname;
+    private String bio;
+    private List<String> preferredLanguage;
+    private Boolean isPublic;
+}

--- a/src/main/java/com/unide/backend/domain/mypage/dto/SubmissionItem.java
+++ b/src/main/java/com/unide/backend/domain/mypage/dto/SubmissionItem.java
@@ -1,0 +1,17 @@
+package com.unide.backend.domain.mypage.dto;
+
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SubmissionItem {
+    private final Long submissionId;
+    private final Long problemId;
+    private final String verdict;
+    private final String language;
+    private final int runtimeMs;
+    private final LocalDateTime submittedAt;
+}

--- a/src/main/java/com/unide/backend/domain/mypage/dto/UserStats.java
+++ b/src/main/java/com/unide/backend/domain/mypage/dto/UserStats.java
@@ -1,0 +1,15 @@
+package com.unide.backend.domain.mypage.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UserStats {
+    private final int totalSolved;
+    private final int totalSubmitted;
+    private final double acceptanceRate;
+    private final int streakDays;
+    private final int rank;
+    private final int rating;
+}

--- a/src/main/java/com/unide/backend/domain/mypage/entity/MyPage.java
+++ b/src/main/java/com/unide/backend/domain/mypage/entity/MyPage.java
@@ -3,7 +3,16 @@ package com.unide.backend.domain.mypage.entity;
 import com.unide.backend.common.entity.BaseTimeEntity;
 import com.unide.backend.domain.user.entity.User;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -21,6 +30,7 @@ public class MyPage extends BaseTimeEntity {
             this.isPublic = true;
         }
     }
+    
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -29,19 +39,19 @@ public class MyPage extends BaseTimeEntity {
     @JoinColumn(name = "user_id", nullable = false, unique = true)
     private User user;
 
-    @Column(name = "nickname", nullable = false, unique = true, length = 50)
+    @Column(nullable = false, unique = true, length = 50)
     private String nickname;
 
-    @Column(name = "avatar_url", length = 500)
+    @Column(length = 500)
     private String avatarUrl;
 
     @Column(columnDefinition = "TEXT")
     private String bio;
 
-    @Column(name = "preferred_language", columnDefinition = "JSON")
+    @Column(columnDefinition = "JSON")
     private String preferredLanguage;
 
-    @Column(name = "is_public", nullable = false, columnDefinition = "BOOLEAN DEFAULT true")
+    @Column(nullable = false, columnDefinition = "BOOLEAN DEFAULT true")
     private Boolean isPublic;
 
     @Builder

--- a/src/main/java/com/unide/backend/domain/mypage/entity/MyPage.java
+++ b/src/main/java/com/unide/backend/domain/mypage/entity/MyPage.java
@@ -1,0 +1,76 @@
+package com.unide.backend.domain.mypage.entity;
+
+import com.unide.backend.common.entity.BaseTimeEntity;
+import com.unide.backend.domain.user.entity.User;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "mypage")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MyPage extends BaseTimeEntity {
+
+    @PrePersist
+    public void prePersist() {
+        if (this.isPublic == null) {
+            this.isPublic = true;
+        }
+    }
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    private User user;
+
+    @Column(name = "nickname", nullable = false, unique = true, length = 50)
+    private String nickname;
+
+    @Column(name = "avatar_url", length = 500)
+    private String avatarUrl;
+
+    @Column(columnDefinition = "TEXT")
+    private String bio;
+
+    @Column(name = "preferred_language", columnDefinition = "JSON")
+    private String preferredLanguage;
+
+    @Column(name = "is_public", nullable = false, columnDefinition = "BOOLEAN DEFAULT true")
+    private Boolean isPublic;
+
+    @Builder
+    public MyPage(User user, String nickname, String avatarUrl, String bio, String preferredLanguage, Boolean isPublic) {
+        this.user = user;
+        this.nickname = nickname;
+        this.avatarUrl = avatarUrl;
+        this.bio = bio;
+        this.preferredLanguage = preferredLanguage;
+        this.isPublic = (isPublic != null) ? isPublic : true;
+    }
+
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public void updateAvatarUrl(String avatarUrl) {
+        this.avatarUrl = avatarUrl;
+    }
+
+    public void updateBio(String bio) {
+        this.bio = bio;
+    }
+
+    public void updatePreferredLanguage(String preferredLanguage) {
+        this.preferredLanguage = preferredLanguage;
+    }
+
+    public void updateIsPublic(Boolean isPublic) {
+        this.isPublic = isPublic;
+    }
+}

--- a/src/main/java/com/unide/backend/domain/mypage/repository/MyPageRepository.java
+++ b/src/main/java/com/unide/backend/domain/mypage/repository/MyPageRepository.java
@@ -1,0 +1,13 @@
+package com.unide.backend.domain.mypage.repository;
+
+import com.unide.backend.domain.mypage.entity.MyPage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MyPageRepository extends JpaRepository<MyPage, Long> {
+    Optional<MyPage> findByUserId(Long userId);
+    boolean existsByUserId(Long userId);
+    boolean existsByNicknameAndUserIdNot(String nickname, Long userId);
+    Optional<MyPage> findByNickname(String nickname);
+}

--- a/src/main/java/com/unide/backend/domain/mypage/service/MyPageService.java
+++ b/src/main/java/com/unide/backend/domain/mypage/service/MyPageService.java
@@ -1,0 +1,189 @@
+package com.unide.backend.domain.mypage.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.unide.backend.domain.mypage.dto.MyPageResponseDto;
+import com.unide.backend.domain.mypage.dto.MyPageUpdateRequestDto;
+import com.unide.backend.domain.mypage.dto.SubmissionItem;
+import com.unide.backend.domain.mypage.dto.UserStats;
+import com.unide.backend.domain.mypage.entity.MyPage;
+import com.unide.backend.domain.mypage.repository.MyPageRepository;
+import com.unide.backend.domain.submission.repository.SubmissionRepository;
+import com.unide.backend.domain.user.entity.User;
+import com.unide.backend.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MyPageService {
+    private final MyPageRepository myPageRepository;
+    private final UserRepository userRepository;
+    private final SubmissionRepository submissionRepository;
+    private final ObjectMapper objectMapper;
+    
+    private static final String DEFAULT_AVATAR_URL = "/images/default-avatar.png";
+
+    public MyPageResponseDto getMyPage(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+        
+        MyPage myPage = myPageRepository.findByUserId(userId).orElse(null);
+        
+        return buildMyPageResponse(user, myPage);
+    }
+
+    public MyPageResponseDto getMyPageByNickname(String nickname, Long requestUserId) {
+        // 먼저 MyPage의 nickname으로 조회 시도
+        MyPage myPage = myPageRepository.findByNickname(nickname).orElse(null);
+        
+        User user;
+        if (myPage != null) {
+            // MyPage에서 찾았으면 해당 User 사용
+            user = myPage.getUser();
+        } else {
+            // MyPage에 없으면 User의 nickname으로 조회
+            user = userRepository.findByNickname(nickname)
+                    .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+            myPage = myPageRepository.findByUserId(user.getId()).orElse(null);
+        }
+        
+        // 비공개 프로필이고 본인이 아닌 경우 접근 거부
+        if (myPage != null && !myPage.getIsPublic() && 
+            (requestUserId == null || !requestUserId.equals(user.getId()))) {
+            throw new IllegalArgumentException("비공개 프로필입니다.");
+        }
+        
+        return buildMyPageResponse(user, myPage);
+    }
+
+    private MyPageResponseDto buildMyPageResponse(User user, MyPage myPage) {
+        Long userId = user.getId();
+
+        List<Long> solvedProblems = submissionRepository.findSolvedProblemsByUserId(userId);
+
+        List<SubmissionItem> recentSubmissions = submissionRepository
+                .findRecentSubmissionsByUserId(userId, PageRequest.of(0, 5))
+                .stream()
+                .map(sub -> new SubmissionItem(
+                        sub.getId(),
+                        sub.getProblem().getProblemId(),
+                        sub.getStatus().name(),
+                        sub.getLanguage().getDisplayName(),
+                        sub.getRuntimeMs() != null ? sub.getRuntimeMs() : 0,
+                        sub.getSubmittedAt()
+                ))
+                .collect(Collectors.toList());
+
+        Long totalSubmitted = submissionRepository.countByUserId(userId);
+        Long totalSolved = submissionRepository.countSolvedByUserId(userId);
+        double acceptanceRate = totalSubmitted > 0 ? (totalSolved * 100.0 / totalSubmitted) : 0.0;
+
+        UserStats stats = new UserStats(
+                totalSolved != null ? totalSolved.intValue() : 0,
+                totalSubmitted != null ? totalSubmitted.intValue() : 0,
+                Math.round(acceptanceRate * 10.0) / 10.0,
+                0, 0, 0
+        );
+
+        List<String> preferredLanguageList = List.of();
+        if (myPage != null && myPage.getPreferredLanguage() != null) {
+            try {
+                preferredLanguageList = objectMapper.readValue(
+                        myPage.getPreferredLanguage(),
+                        objectMapper.getTypeFactory().constructCollectionType(List.class, String.class)
+                );
+            } catch (JsonProcessingException e) {
+                // JSON 파싱 실패 시 빈 리스트 유지
+                preferredLanguageList = List.of();
+            }
+        }
+
+        return MyPageResponseDto.builder()
+                .userId(user.getId())
+                .nickname(myPage != null && myPage.getNickname() != null 
+                        ? myPage.getNickname() 
+                        : user.getNickname())
+                // 아바타 url이 따로 없을 경우 기본 이미지 url 적용
+                .avatarUrl(myPage != null && myPage.getAvatarUrl() != null 
+                        ? myPage.getAvatarUrl() 
+                        : DEFAULT_AVATAR_URL)
+                .bio(myPage != null ? myPage.getBio() : null)
+                .preferredLanguage(preferredLanguageList)
+                .role(user.getRole().toString())
+                .joinedAt(user.getCreatedAt())
+                .isPublic(myPage != null ? myPage.getIsPublic() : true)
+                .solvedProblems(solvedProblems)
+                .bookmarkedProblems(List.of())
+                .recentSubmissions(recentSubmissions)
+                .stats(stats)
+                .build();
+    }
+
+    @Transactional
+    public MyPageResponseDto createMyPage(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        if (myPageRepository.existsByUserId(userId)) {
+            throw new IllegalArgumentException("이미 마이페이지가 존재합니다.");
+        }
+
+        MyPage myPage = MyPage.builder()
+                .user(user)
+                .nickname(user.getNickname())
+                .isPublic(true)
+                .build();
+
+        myPageRepository.save(myPage);
+        return buildMyPageResponse(user, myPage);
+    }
+
+    @Transactional
+    public MyPageResponseDto updateMyPage(Long userId, MyPageUpdateRequestDto requestDto) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+        
+        MyPage myPage = myPageRepository.findByUserId(userId)
+                .orElseThrow(() -> new IllegalArgumentException("마이페이지를 찾을 수 없습니다."));
+
+        if (requestDto.getNickname() != null) {
+            // 닉네임 중복 확인 (본인 제외)
+            if (myPageRepository.existsByNicknameAndUserIdNot(requestDto.getNickname(), userId)) {
+                throw new IllegalArgumentException("이미 사용 중인 닉네임입니다.");
+            }
+            myPage.updateNickname(requestDto.getNickname());
+        }
+        if (requestDto.getBio() != null) {
+            myPage.updateBio(requestDto.getBio());
+        }
+        if (requestDto.getPreferredLanguage() != null) {
+            try {
+                String jsonLanguage = objectMapper.writeValueAsString(requestDto.getPreferredLanguage());
+                myPage.updatePreferredLanguage(jsonLanguage);
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException("선호 언어 JSON 변환 실패", e);
+            }
+        }
+        if (requestDto.getIsPublic() != null) {
+            myPage.updateIsPublic(requestDto.getIsPublic());
+        }
+
+        myPageRepository.save(myPage);
+        return buildMyPageResponse(user, myPage);
+    }
+
+    @Transactional
+    public void deleteMyPage(Long userId) {
+        MyPage myPage = myPageRepository.findByUserId(userId)
+                .orElseThrow(() -> new IllegalArgumentException("마이페이지를 찾을 수 없습니다."));
+
+        myPageRepository.delete(myPage);
+    }
+}

--- a/src/main/java/com/unide/backend/domain/problem/entity/Problem.java
+++ b/src/main/java/com/unide/backend/domain/problem/entity/Problem.java
@@ -1,0 +1,43 @@
+package com.unide.backend.domain.problem.entity;
+
+import com.unide.backend.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "problem")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Problem extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "problem_id")
+    private Long problemId;
+
+    @Column(nullable = false, length = 255)
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Column(length = 50)
+    private String difficulty;
+
+    @Column(nullable = false)
+    private Integer timeLimit;
+
+    @Column(nullable = false)
+    private Integer memoryLimit;
+
+    @Builder
+    public Problem(String title, String description, String difficulty, Integer timeLimit, Integer memoryLimit) {
+        this.title = title;
+        this.description = description;
+        this.difficulty = difficulty;
+        this.timeLimit = timeLimit;
+        this.memoryLimit = memoryLimit;
+    }
+}

--- a/src/main/java/com/unide/backend/domain/problem/repository/ProblemRepository.java
+++ b/src/main/java/com/unide/backend/domain/problem/repository/ProblemRepository.java
@@ -1,0 +1,7 @@
+package com.unide.backend.domain.problem.repository;
+
+import com.unide.backend.domain.problem.entity.Problem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProblemRepository extends JpaRepository<Problem, Long> {
+}

--- a/src/main/java/com/unide/backend/domain/submission/entity/ProgrammingLanguage.java
+++ b/src/main/java/com/unide/backend/domain/submission/entity/ProgrammingLanguage.java
@@ -1,0 +1,18 @@
+package com.unide.backend.domain.submission.entity;
+
+public enum ProgrammingLanguage {
+    PYTHON("Python"),
+    JAVA("Java"),
+    CPP("C++"),
+    C("C");
+
+    private final String displayName;
+
+    ProgrammingLanguage(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+}

--- a/src/main/java/com/unide/backend/domain/submission/entity/Submission.java
+++ b/src/main/java/com/unide/backend/domain/submission/entity/Submission.java
@@ -1,0 +1,70 @@
+package com.unide.backend.domain.submission.entity;
+
+import java.time.LocalDateTime;
+
+import com.unide.backend.common.entity.BaseTimeEntity;
+import com.unide.backend.domain.problem.entity.Problem;
+import com.unide.backend.domain.user.entity.User;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "submission")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Submission extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "problem_id", nullable = false)
+    private Problem problem;
+
+    @Column(columnDefinition = "LONGTEXT")
+    private String code;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ProgrammingLanguage language;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private SubmissionStatus status;
+
+    @Column(name = "runtime_ms")
+    private Integer runtimeMs;
+
+    @Column
+    private Integer memory;
+
+    @Column(name = "submitted_at")
+    private LocalDateTime submittedAt;
+
+    @Builder
+    public Submission(User user, Problem problem, String code, ProgrammingLanguage language) {
+        this.user = user;
+        this.problem = problem;
+        this.code = code;
+        this.language = language;
+        this.status = SubmissionStatus.PENDING;
+        this.submittedAt = LocalDateTime.now();
+    }
+
+    public void updateStatus(SubmissionStatus status) {
+        this.status = status;
+    }
+
+    public void updateResult(Integer runtimeMs, Integer memory) {
+        this.runtimeMs = runtimeMs;
+        this.memory = memory;
+    }
+}

--- a/src/main/java/com/unide/backend/domain/submission/entity/SubmissionStatus.java
+++ b/src/main/java/com/unide/backend/domain/submission/entity/SubmissionStatus.java
@@ -1,0 +1,22 @@
+package com.unide.backend.domain.submission.entity;
+
+public enum SubmissionStatus {
+    PENDING("대기중"),
+    GRADING("채점중"),
+    AC("정답"),
+    WA("오답"),
+    CE("컴파일 에러"),
+    RE("런타임 에러"),
+    TLE("시간 초과"),
+    MLE("메모리 초과");
+
+    private final String description;
+
+    SubmissionStatus(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/src/main/java/com/unide/backend/domain/submission/repository/SubmissionRepository.java
+++ b/src/main/java/com/unide/backend/domain/submission/repository/SubmissionRepository.java
@@ -1,0 +1,23 @@
+package com.unide.backend.domain.submission.repository;
+
+import com.unide.backend.domain.submission.entity.Submission;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface SubmissionRepository extends JpaRepository<Submission, Long> {
+    @Query("SELECT DISTINCT s.problem.problemId FROM Submission s WHERE s.user.id = :userId AND s.status = 'AC' ORDER BY s.problem.problemId")
+    List<Long> findSolvedProblemsByUserId(@Param("userId") Long userId);
+
+    @Query("SELECT s FROM Submission s WHERE s.user.id = :userId ORDER BY s.submittedAt DESC")
+    List<Submission> findRecentSubmissionsByUserId(@Param("userId") Long userId, Pageable pageable);
+
+    @Query("SELECT COUNT(s) FROM Submission s WHERE s.user.id = :userId")
+    Long countByUserId(@Param("userId") Long userId);
+
+    @Query("SELECT COUNT(s) FROM Submission s WHERE s.user.id = :userId AND s.status = 'AC'")
+    Long countSolvedByUserId(@Param("userId") Long userId);
+}

--- a/src/main/java/com/unide/backend/domain/user/entity/User.java
+++ b/src/main/java/com/unide/backend/domain/user/entity/User.java
@@ -2,19 +2,28 @@
 
 package com.unide.backend.domain.user.entity;
 
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
 import com.unide.backend.common.entity.BaseTimeEntity;
 import com.unide.backend.domain.terms.entity.UserTermsConsent;
-import jakarta.persistence.*;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import java.time.LocalDateTime;
-import java.time.Duration;
 
 @Getter
 @Entity
@@ -129,5 +138,9 @@ public class User extends BaseTimeEntity {
 
     public void markAsSocialAccount() {
         this.isSocialAccount = true;
+    }
+
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
     }
 }

--- a/src/main/java/com/unide/backend/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/unide/backend/domain/user/repository/UserRepository.java
@@ -2,10 +2,11 @@
 
 package com.unide.backend.domain.user.repository;
 
-import com.unide.backend.domain.user.entity.User;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
+import com.unide.backend.domain.user.entity.User;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     // 이메일이 존재하는지 확인하는 메서드
@@ -22,4 +23,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     // 닉네임으로 사용자를 찾는 메서드
     Optional<User> findByNickname(String nickname);
+
+    // 특정 ID를 제외하고 닉네임이 존재하는지 확인하는 메서드
+    boolean existsByNicknameAndIdNot(String nickname, Long id);
 }

--- a/src/main/java/com/unide/backend/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/unide/backend/domain/user/repository/UserRepository.java
@@ -19,4 +19,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     // 이메일로 사용자를 찾는 메서드
     Optional<User> findByEmail(String email);
+
+    // 닉네임으로 사용자를 찾는 메서드
+    Optional<User> findByNickname(String nickname);
 }

--- a/src/main/java/com/unide/backend/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/unide/backend/global/security/config/SecurityConfig.java
@@ -6,10 +6,10 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 import com.unide.backend.global.security.jwt.JwtAuthenticationFilter;
@@ -50,11 +50,19 @@ public class SecurityConfig {
                 .requestMatchers("/api/auth/**").permitAll()
                 // 포트폴리오 업로드 경로는 누구나 접근 가능하도록 허용
                 .requestMatchers("/api/upload/portfolio").permitAll()
+                // 닉네임으로 마이페이지 조회는 누구나 접근 가능 (GET만 허용)
+                .requestMatchers("GET", "/api/mypage/**").permitAll()
                 // MANAGER 역할을 가진 사용자만 접근 가능
                 .requestMatchers("/api/admin/**").hasRole("MANAGER")
+                // 마이페이지 수정/삭제는 인증 필요 (PUT, DELETE)
+                .requestMatchers("PUT", "/api/mypage").authenticated()
+                .requestMatchers("DELETE", "/api/mypage").authenticated()
                 // 나머지 모든 요청은 일단 인증된 사용자만 접근 가능하도록 설정
                 .anyRequest().authenticated()
             )
+            
+            .formLogin(form -> form.disable())
+            .httpBasic(basic -> basic.disable())
 
             .oauth2Login(oauth2 -> oauth2
                 .userInfoEndpoint(userInfo -> userInfo.userService(customOAuth2UserService))


### PR DESCRIPTION
## 주요 변경사항
- 회원가입 시 MyPage 자동 생성
- MyPage 조회 API (본인/닉네임으로 조회)
- MyPage 수정 API (nickname, bio, preferredLanguage, isPublic)
- User와 MyPage의 nickname 동기화
- MyPageResponseDto에 id, joinedAt, updatedAt 필드 추가

## 구현 내용
- `AuthService`: 회원가입 시 MyPage 자동 생성
- `MyPageService`: 조회, 생성, 수정, 삭제 기능
- `User`: updateNickname 메서드 추가
- `UserRepository`: existsByNicknameAndIdNot 메서드 추가
- `Bookmark`: 향후 북마크 기능을 위한 엔티티 추가
- delete 기능을 활용하여 초기화 하기 

## TODO (추후 구현 필요)
- 제출 기록 상세 기능
- 문제 풀이 통계 고도화
- 북마크 기능 완성